### PR TITLE
Added 10 instances of dummy data to the Payment Type Table via manage.py loaddata and paymentType.json

### DIFF
--- a/API/fixtures/paymentType.json
+++ b/API/fixtures/paymentType.json
@@ -1,0 +1,72 @@
+[
+ {
+ 		"model": "API.paymenttype",
+ 		"fields":{
+		    "account_number": 5464471,
+		    "customer": 2
+			}
+ },
+ {
+ 		"model": "API.paymenttype",
+ 		"fields":{
+		    "account_number": 2598903,
+		    "customer": 3
+			}
+ },
+ {
+ 		"model": "API.paymenttype",
+ 		"fields":{
+		    "account_number": 6088653,
+		    "customer": 4
+			}
+ },
+ {
+ 		"model": "API.paymenttype",
+ 		"fields":{
+		    "account_number": 3321295,
+		    "customer": 5
+			}
+ },
+ {
+ 		"model": "API.paymenttype",
+ 		"fields":{
+		    "account_number": 3531924,
+		    "customer": 6
+			}
+ },
+ {
+ 		"model": "API.paymenttype",
+ 		"fields":{
+		    "account_number": 1405370,
+		    "customer": 7
+			}
+ },
+ {
+ 		"model": "API.paymenttype",
+ 		"fields":{
+		    "account_number": 7214490,
+		    "customer": 8
+			}
+ },
+ {
+ 		"model": "API.paymenttype",
+ 		"fields":{
+		    "account_number": 8991365,
+		    "customer": 1
+			}
+ },
+ {
+ 		"model": "API.paymenttype",
+ 		"fields":{
+		    "account_number": 8790037,
+		    "customer": 9
+			}
+ },
+ {
+ 		"model": "API.paymenttype",
+ 		"fields":{
+		    "account_number": 4679853,
+		    "customer": 10
+			}
+ }
+ ] 


### PR DESCRIPTION
## 1. TITLE:
As seen above

## 2. STATUS:
Done

## 3. MIGRATIONS:
***YES*** (has been migrated) *or* ***NO*** (has not been migrated)
None needed

## 4. DESCRIPTION:
***Rationale(reason behind updated changes)***
Part of the features needed for correct implementation, testing, and debugging of the API
***Expected behavior of changes***
Now 10 instances of dummy data should populate in the Payment Types Table

## 5. RELATED TICKETS:
All other dummy data tickets


## 6. FILES CHANGED:
paymentTypes.json 


## 7. STEPS TO RUN PROJECT:

python manage.py loaddata paymentType.json
python manage.py runserver



### For reference: [Bangazon Employee Handbook: Pull Requests](https://github.com/nashville-software-school/bangazon-llc/blob/master/EMPLOYEE_HANDBOOK.md)
